### PR TITLE
fix(notification): SES verification identity/message mismatch + reset on address change

### DIFF
--- a/notification_service/src/main/java/vacademy/io/notification_service/features/announcements/service/EmailConfigurationService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/announcements/service/EmailConfigurationService.java
@@ -441,6 +441,18 @@ public class EmailConfigurationService {
             String newFrom = treatAsNoName ? newEmail : (newName + " <" + newEmail + ">");
             existingConfigNode.put(NotificationConstants.FROM, newFrom);
 
+            // If the from-address actually changed, any prior SES verification was for the OLD
+            // address and no longer applies. Reset the verification state so the from-address and
+            // the verified identity can't drift apart — otherwise the UI would show a stale
+            // verified/pending badge for a different address and sending would silently fall back
+            // to the platform default. A fresh "Verify sender" re-establishes it for the new address.
+            if (!previousEmail.isBlank() && !previousEmail.equalsIgnoreCase(newEmail)) {
+                existingConfigNode.remove(NotificationConstants.VERIFICATION_STATUS);
+                existingConfigNode.remove(NotificationConstants.VERIFIED);
+                existingConfigNode.remove(NotificationConstants.VERIFICATION_IDENTITY);
+                existingConfigNode.remove(NotificationConstants.VERIFIED_AT);
+            }
+
             String updatedSettings = objectMapper.writeValueAsString(rootNode);
             boolean persisted = instituteInternalService.updateInstituteSettings(
                     instituteId, updatedSettings, authToken);

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/email_verification/service/EmailSenderVerificationService.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/email_verification/service/EmailSenderVerificationService.java
@@ -158,7 +158,7 @@ public class EmailSenderVerificationService {
                 .mode(storedMode)
                 .status(liveStatus)
                 .verified(verified)
-                .message(messageFor(storedMode, liveStatus, email, extractDomain(email)))
+                .message(messageFor(storedMode, liveStatus, identity, extractDomain(identity)))
                 .dnsRecords(dnsRecords)
                 .build();
     }


### PR DESCRIPTION
## Bugs
In the admin **Notification Settings → Email** SES sender verification:

1. **Wrong address in the status message.** `getStatus` built its message from the **from-address** (`email`) instead of the **identity** AWS actually verified. After the sender was edited, the UI showed *"AWS sent a confirmation email to <from-address>"* when it really went to the previously-submitted identity — the exact mismatch that caused confusion in testing.
2. **From-address and identity drift.** Changing the from-address (`updateEmailConfiguration`) left the old `verification_identity`/`verification_status` in place, so the two silently diverged — a verified/pending badge would show for a *different* address than the one mail sends from, and sending would fall back to the platform default.

## Fix
1. `EmailSenderVerificationService.getStatus` → message uses `identity` (and its domain), not `email`.
2. `EmailConfigurationService.updateEmailConfiguration` → when the from-address actually changes, reset `verification_status`/`verified`/`verification_identity`/`verified_at` so a fresh **Verify sender** re-establishes it for the new address.

## Verify
`mvn -o compile` → 0 compilation errors. Merging auto-deploys (change under `notification_service/**` matches the deploy workflow's push path filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)