### PR TITLE
fix(whatsapp inbox): close the attachment gate hole, plus CodeFactor cleanup and contract tests

### DIFF
--- a/frontend-admin-dashboard/src/routes/communication/inbox/-components/reply-box.tsx
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-components/reply-box.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
     PaperPlaneRight,
     FileText,
@@ -15,91 +15,13 @@ import {
     getSessionWindow,
     getInboxMediaSupport,
     type SessionWindow,
-    type WhatsAppMediaKind,
+    type SendReplyOptions,
 } from '../-services/inbox-api';
 import { useInboxStore } from '../-stores/inbox-store';
+import { useAttachment, formatSize, formatDuration } from '../-hooks/use-attachment';
 import { getInstituteId } from '@/constants/helper';
-import { getChatUser } from '@/services/chat/getChatUser';
-import { UploadFileInS3, getPublicUrl } from '@/services/upload_file';
 import { sendNotification } from '@/services/unified-send-service';
 import { listTemplates, type WhatsAppTemplateDTO } from '@/routes/communication/whatsapp-templates/-services/template-api';
-
-/**
- * Meta's ceilings for a free-form media message. Checked here so an oversized file is refused
- * before it is uploaded, rather than after a round trip that ends in an opaque provider error.
- */
-const MEDIA_LIMITS: Record<WhatsAppMediaKind, number> = {
-    image: 5 * 1024 * 1024,
-    video: 16 * 1024 * 1024,
-    audio: 16 * 1024 * 1024,
-    document: 100 * 1024 * 1024,
-};
-
-/** The formats WhatsApp renders natively. Anything else has to travel as a document. */
-const NATIVE_FORMATS: Record<Exclude<WhatsAppMediaKind, 'document'>, string[]> = {
-    image: ['image/jpeg', 'image/png'],
-    video: ['video/mp4', 'video/3gpp'],
-    audio: ['audio/aac', 'audio/mpeg', 'audio/mp4', 'audio/amr', 'audio/ogg'],
-};
-
-interface Attachment {
-    url: string;
-    name: string;
-    kind: WhatsAppMediaKind;
-    size: number;
-    /** Set when the file was downgraded to a document because WhatsApp cannot render its format. */
-    downgradedFrom?: string;
-}
-
-function formatSize(bytes: number): string {
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatDuration(seconds: number): string {
-    return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`;
-}
-
-/**
- * A recording format WhatsApp will actually play, or null if this browser can only produce one it
- * rejects.
- *
- * This is the whole difficulty with voice notes: MediaRecorder's universal format is WebM/Opus, and
- * WhatsApp accepts neither WebM nor any container it does not name. MP4/AAC and Ogg/Opus are the
- * two it does accept that browsers can also record, so we take whichever is on offer and refuse
- * rather than send a file that would come back as an opaque provider error.
- */
-function pickRecordingFormat(): { mime: string; ext: string } | null {
-    if (typeof MediaRecorder === 'undefined') return null;
-    const candidates = [
-        { mime: 'audio/mp4', ext: 'm4a' },
-        { mime: 'audio/mp4;codecs=mp4a.40.2', ext: 'm4a' },
-        { mime: 'audio/ogg;codecs=opus', ext: 'ogg' },
-        { mime: 'audio/ogg', ext: 'ogg' },
-    ];
-    return candidates.find((c) => MediaRecorder.isTypeSupported(c.mime)) ?? null;
-}
-
-/**
- * Which WhatsApp message type a file should be sent as.
- *
- * A HEIC photo, a .mov clip or a FLAC track are all real files an admin will pick, and WhatsApp
- * refuses every one of them as its native type — so they are sent as documents instead, which
- * always delivers. The caller tells the admin when that happens rather than silently changing
- * what they asked for.
- */
-function classifyAttachment(file: File): { kind: WhatsAppMediaKind; downgradedFrom?: string } {
-    const mime = (file.type || '').toLowerCase();
-
-    for (const [kind, formats] of Object.entries(NATIVE_FORMATS)) {
-        const family = `${kind === 'image' ? 'image' : kind === 'video' ? 'video' : 'audio'}/`;
-        if (!mime.startsWith(family)) continue;
-        return formats.includes(mime)
-            ? { kind: kind as WhatsAppMediaKind }
-            : { kind: 'document', downgradedFrom: kind };
-    }
-
-    return { kind: 'document' };
-}
 
 interface Props {
     phone: string;
@@ -116,24 +38,28 @@ export function ReplyBox({ phone }: Props) {
     const markConversationAnswered = useInboxStore((s) => s.markConversationAnswered);
     const instituteId = getInstituteId() || '';
 
-    const [attachment, setAttachment] = useState<Attachment | null>(null);
-    const [uploading, setUploading] = useState(false);
     const [window24h, setWindow24h] = useState<SessionWindow | null>(null);
     const [mediaSupport, setMediaSupport] = useState(getInboxMediaSupport());
-    const [recording, setRecording] = useState(false);
-    const [recordedSeconds, setRecordedSeconds] = useState(0);
-    const fileInputRef = useRef<HTMLInputElement>(null);
-    const recorderRef = useRef<MediaRecorder | null>(null);
-    const chunksRef = useRef<Blob[]>([]);
-    const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
-    const discardRef = useRef(false);
+
+    const {
+        attachment,
+        clearAttachment,
+        uploading,
+        recording,
+        recordedSeconds,
+        fileInputRef,
+        openFilePicker,
+        handleFilePick,
+        startRecording,
+        stopRecording,
+    } = useAttachment({ instituteId, mediaSupport });
 
     // How much of Meta's 24-hour reply window is left. Null when the backend does not report it,
     // in which case the composer behaves exactly as it always has.
     useEffect(() => {
         let cancelled = false;
         setWindow24h(null);
-        setAttachment(null);
+        clearAttachment();
         getSessionWindow(phone, instituteId).then((w) => {
             if (cancelled) return;
             setWindow24h(w);
@@ -153,172 +79,30 @@ export function ReplyBox({ phone }: Props) {
         }
     }, [showTemplates]);
 
-    /** Validate, upload and stage one file — shared by the file picker and the voice recorder. */
-    const stageFile = useCallback(
-        async (file: File) => {
-            const { kind, downgradedFrom } = classifyAttachment(file);
-            const limit = MEDIA_LIMITS[kind];
-            if (file.size > limit) {
-                toast.error(
-                    `${file.name} is ${formatSize(file.size)}. WhatsApp allows ${formatSize(limit)} for ${kind === 'document' ? 'documents' : `${kind}s`}.`
-                );
-                return;
-            }
-
-            setUploading(true);
-            try {
-                const { userId } = getChatUser();
-                const fileId = await UploadFileInS3(
-                    file,
-                    setUploading,
-                    userId,
-                    'WHATSAPP_INBOX',
-                    instituteId,
-                    true
-                );
-                if (!fileId) {
-                    toast.error('Upload failed. Please try again.');
-                    return;
-                }
-                // WhatsApp fetches the file itself, so this has to be a public URL, not a file id.
-                const url = await getPublicUrl(fileId);
-                if (!url) {
-                    toast.error('Could not get a public link for the uploaded file.');
-                    return;
-                }
-                setAttachment({ url, name: file.name, kind, size: file.size, downgradedFrom });
-                if (downgradedFrom) {
-                    toast.info(
-                        `WhatsApp can't show ${file.type || 'this format'} as ${downgradedFrom === 'image' ? 'a photo' : `${downgradedFrom}`}, so it will be sent as a document.`
-                    );
-                }
-            } catch (err) {
-                console.error(err);
-                toast.error('Upload failed. Please try again.');
-            } finally {
-                setUploading(false);
-            }
-        },
-        [instituteId]
-    );
-
-    /** Release the mic and the timer. Safe to call twice. */
-    const teardownRecorder = useCallback(() => {
-        if (tickRef.current) {
-            clearInterval(tickRef.current);
-            tickRef.current = null;
-        }
-        recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
-        recorderRef.current = null;
-        setRecording(false);
-        setRecordedSeconds(0);
-    }, []);
-
-    // Never leave the microphone open because the admin navigated away mid-recording.
-    useEffect(() => teardownRecorder, [teardownRecorder]);
-
-    const startRecording = useCallback(async () => {
-        if (mediaSupport === 'no') {
-            toast.error(
-                'Voice notes need the updated notification service. The feature is built but not deployed yet.'
-            );
-            return;
-        }
-        const format = pickRecordingFormat();
-        if (!format) {
-            toast.error(
-                'This browser can only record WebM audio, which WhatsApp rejects. Try Chrome 126+, Safari or Firefox.'
-            );
-            return;
-        }
-
-        try {
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            const recorder = new MediaRecorder(stream, { mimeType: format.mime });
-            chunksRef.current = [];
-            discardRef.current = false;
-
-            recorder.ondataavailable = (e) => {
-                if (e.data.size > 0) chunksRef.current.push(e.data);
-            };
-            recorder.onstop = async () => {
-                const chunks = chunksRef.current;
-                chunksRef.current = [];
-                const discarded = discardRef.current;
-                teardownRecorder();
-                if (discarded || chunks.length === 0) return;
-
-                const blob = new Blob(chunks, { type: format.mime });
-                const file = new File([blob], `voice-note-${Date.now()}.${format.ext}`, {
-                    // The bare mime without codec parameters — classifyAttachment matches on it.
-                    type: format.mime.split(';')[0],
-                });
-                await stageFile(file);
-            };
-
-            recorderRef.current = recorder;
-            recorder.start();
-            setRecording(true);
-            setRecordedSeconds(0);
-            tickRef.current = setInterval(() => setRecordedSeconds((n) => n + 1), 1000);
-        } catch (err) {
-            console.error(err);
-            toast.error('Could not access the microphone. Check the browser permission.');
-        }
-    }, [mediaSupport, stageFile, teardownRecorder]);
-
-    const stopRecording = useCallback((discard: boolean) => {
-        discardRef.current = discard;
-        const recorder = recorderRef.current;
-        if (recorder && recorder.state !== 'inactive') {
-            recorder.stop(); // onstop uploads or discards, then tears down
-        }
-    }, []);
-
-    /**
-     * A greyed-out button that does nothing when clicked reads as a bug. If the backend cannot
-     * accept attachments yet, say so out loud — `/inbox/send` ignores fields it does not know, so
-     * an older backend would deliver the caption as a plain text message and drop the file with
-     * nobody told.
-     */
-    const openFilePicker = useCallback(() => {
-        if (mediaSupport === 'no') {
-            toast.error(
-                'Attachments need the updated notification service. The feature is built but not deployed yet.'
-            );
-            return;
-        }
-        fileInputRef.current?.click();
-    }, [mediaSupport]);
-
-    const handleFilePick = useCallback(
-        async (e: React.ChangeEvent<HTMLInputElement>) => {
-            const file = e.target.files?.[0];
-            // Reset immediately so picking the same file twice still fires a change event.
-            e.target.value = '';
-            if (!file) return;
-
-            await stageFile(file);
-        },
-        [stageFile]
-    );
-
     const handleSend = useCallback(async () => {
         if ((!text.trim() && !attachment) || sending) return;
+
+        if (attachment && mediaSupport !== 'yes') {
+            toast.error(
+                mediaSupport === 'no'
+                    ? 'Attachments need the updated notification service. The feature is built but not deployed yet.'
+                    : 'Still checking whether this backend accepts attachments — try again in a moment.'
+            );
+            return;
+        }
 
         setSending(true);
         try {
             // With an attachment the typed text rides along as the caption.
             const caption = text.trim();
-            const sent = await sendReply(phone, caption, instituteId, {
-                ...(attachment
-                    ? {
-                          mediaType: attachment.kind,
-                          mediaUrl: attachment.url,
-                          filename: attachment.name,
-                      }
-                    : {}),
-            });
+            const options: SendReplyOptions = attachment
+                ? {
+                      mediaType: attachment.kind,
+                      mediaUrl: attachment.url,
+                      filename: attachment.name,
+                  }
+                : {};
+            const sent = await sendReply(phone, caption, instituteId, options);
             appendMessage(sent);
             updateConversationLastMessage(
                 phone,
@@ -329,7 +113,7 @@ export function ReplyBox({ phone }: Props) {
             // rather than waiting for the next poll.
             markConversationAnswered(phone);
             setText('');
-            setAttachment(null);
+            clearAttachment();
         } catch (err) {
             console.error(err);
             // A refused send is now recorded in the thread as "Not delivered", so point there
@@ -345,6 +129,8 @@ export function ReplyBox({ phone }: Props) {
     }, [
         text,
         attachment,
+        clearAttachment,
+        mediaSupport,
         phone,
         sending,
         appendMessage,
@@ -515,7 +301,7 @@ export function ReplyBox({ phone }: Props) {
                         </p>
                     </div>
                     <button
-                        onClick={() => setAttachment(null)}
+                        onClick={clearAttachment}
                         className="rounded p-1 text-gray-400 hover:bg-gray-200 hover:text-gray-600"
                         title="Remove attachment"
                     >

--- a/frontend-admin-dashboard/src/routes/communication/inbox/-hooks/use-attachment.ts
+++ b/frontend-admin-dashboard/src/routes/communication/inbox/-hooks/use-attachment.ts
@@ -1,0 +1,276 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { getChatUser } from '@/services/chat/getChatUser';
+import { UploadFileInS3, getPublicUrl } from '@/services/upload_file';
+import type { WhatsAppMediaKind } from '../-services/inbox-api';
+
+/**
+ * Meta's ceilings for a free-form media message. Checked before upload so an oversized file is
+ * refused here rather than after a round trip that ends in an opaque provider error.
+ */
+const MEDIA_LIMITS: Record<WhatsAppMediaKind, number> = {
+    image: 5 * 1024 * 1024,
+    video: 16 * 1024 * 1024,
+    audio: 16 * 1024 * 1024,
+    document: 100 * 1024 * 1024,
+};
+
+/** The formats WhatsApp renders natively. Anything else has to travel as a document. */
+const NATIVE_FORMATS: Record<Exclude<WhatsAppMediaKind, 'document'>, string[]> = {
+    image: ['image/jpeg', 'image/png'],
+    video: ['video/mp4', 'video/3gpp'],
+    audio: ['audio/aac', 'audio/mpeg', 'audio/mp4', 'audio/amr', 'audio/ogg'],
+};
+
+export interface Attachment {
+    url: string;
+    name: string;
+    kind: WhatsAppMediaKind;
+    size: number;
+    /** Set when the file was downgraded to a document because WhatsApp cannot render its format. */
+    downgradedFrom?: string;
+}
+
+export function formatSize(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function formatDuration(seconds: number): string {
+    return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`;
+}
+
+/**
+ * Which WhatsApp message type a file should be sent as.
+ *
+ * A HEIC photo, a .mov clip and a FLAC track are all files an admin will realistically pick, and
+ * WhatsApp refuses every one of them as its native type — so they go as documents instead, which
+ * always delivers. The caller tells the admin when that happens rather than silently changing what
+ * they asked for.
+ */
+function classifyAttachment(file: File): { kind: WhatsAppMediaKind; downgradedFrom?: string } {
+    const mime = (file.type || '').toLowerCase();
+    const family = (Object.keys(NATIVE_FORMATS) as Array<keyof typeof NATIVE_FORMATS>).find((k) =>
+        mime.startsWith(`${k}/`)
+    );
+
+    if (!family) return { kind: 'document' };
+    return NATIVE_FORMATS[family].includes(mime)
+        ? { kind: family }
+        : { kind: 'document', downgradedFrom: family };
+}
+
+/**
+ * A recording format WhatsApp will actually play, or null if this browser can only produce one it
+ * rejects.
+ *
+ * This is the whole difficulty with voice notes: MediaRecorder's universal format is WebM/Opus, and
+ * WhatsApp accepts neither WebM nor any container it does not name. MP4/AAC and Ogg/Opus are the
+ * two it does accept that browsers can also record, so we take whichever is on offer and refuse
+ * rather than send a file that comes back as an opaque provider error.
+ */
+function pickRecordingFormat(): { mime: string; ext: string } | null {
+    if (typeof MediaRecorder === 'undefined') return null;
+    const candidates = [
+        { mime: 'audio/mp4', ext: 'm4a' },
+        { mime: 'audio/mp4;codecs=mp4a.40.2', ext: 'm4a' },
+        { mime: 'audio/ogg;codecs=opus', ext: 'ogg' },
+        { mime: 'audio/ogg', ext: 'ogg' },
+    ];
+    return candidates.find((c) => MediaRecorder.isTypeSupported(c.mime)) ?? null;
+}
+
+interface Options {
+    instituteId: string;
+    /**
+     * Whether the backend accepts attachments at all. Only 'yes' is permission: 'unknown' means the
+     * probe never answered, and `/inbox/send` ignores fields it does not know — so treating that as
+     * a yes would deliver the caption alone with the file dropped and nobody told.
+     */
+    mediaSupport: 'unknown' | 'yes' | 'no';
+}
+
+/**
+ * Everything the composer needs to attach a file or record a voice note: validation against Meta's
+ * rules, upload to a public URL, and the MediaRecorder lifecycle.
+ */
+export function useAttachment({ instituteId, mediaSupport }: Options) {
+    const [attachment, setAttachment] = useState<Attachment | null>(null);
+    const [uploading, setUploading] = useState(false);
+    const [recording, setRecording] = useState(false);
+    const [recordedSeconds, setRecordedSeconds] = useState(0);
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const recorderRef = useRef<MediaRecorder | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+    const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const discardRef = useRef(false);
+
+    const unsupportedMessage = useCallback(
+        (what: string) =>
+            mediaSupport === 'no'
+                ? `${what} need the updated notification service. The feature is built but not deployed yet.`
+                : `Still checking whether this backend accepts attachments — try again in a moment.`,
+        [mediaSupport]
+    );
+
+    /** Validate, upload and stage one file — shared by the file picker and the voice recorder. */
+    const stageFile = useCallback(
+        async (file: File) => {
+            const { kind, downgradedFrom } = classifyAttachment(file);
+            const limit = MEDIA_LIMITS[kind];
+            if (file.size > limit) {
+                toast.error(
+                    `${file.name} is ${formatSize(file.size)}. WhatsApp allows ${formatSize(limit)} for ${kind === 'document' ? 'documents' : `${kind}s`}.`
+                );
+                return;
+            }
+
+            setUploading(true);
+            try {
+                const { userId } = getChatUser();
+                const fileId = await UploadFileInS3(
+                    file,
+                    setUploading,
+                    userId,
+                    'WHATSAPP_INBOX',
+                    instituteId,
+                    true
+                );
+                if (!fileId) {
+                    toast.error('Upload failed. Please try again.');
+                    return;
+                }
+                // WhatsApp fetches the file itself, so this has to be a public URL, not a file id.
+                const url = await getPublicUrl(fileId);
+                if (!url) {
+                    toast.error('Could not get a public link for the uploaded file.');
+                    return;
+                }
+                setAttachment({ url, name: file.name, kind, size: file.size, downgradedFrom });
+                if (downgradedFrom) {
+                    toast.info(
+                        `WhatsApp can't show ${file.type || 'this format'} as ${downgradedFrom === 'image' ? 'a photo' : downgradedFrom}, so it will be sent as a document.`
+                    );
+                }
+            } catch (err) {
+                console.error(err);
+                toast.error('Upload failed. Please try again.');
+            } finally {
+                setUploading(false);
+            }
+        },
+        [instituteId]
+    );
+
+    /**
+     * A greyed-out button that does nothing when clicked reads as a bug, so an unavailable backend
+     * says so out loud instead of swallowing the click.
+     */
+    const openFilePicker = useCallback(() => {
+        if (mediaSupport !== 'yes') {
+            toast.error(unsupportedMessage('Attachments'));
+            return;
+        }
+        fileInputRef.current?.click();
+    }, [mediaSupport, unsupportedMessage]);
+
+    const handleFilePick = useCallback(
+        async (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+            // Reset immediately so picking the same file twice still fires a change event.
+            e.target.value = '';
+            if (file) await stageFile(file);
+        },
+        [stageFile]
+    );
+
+    /** Release the mic and the timer. Safe to call twice. */
+    const teardownRecorder = useCallback(() => {
+        if (tickRef.current) {
+            clearInterval(tickRef.current);
+            tickRef.current = null;
+        }
+        recorderRef.current?.stream.getTracks().forEach((t) => t.stop());
+        recorderRef.current = null;
+        setRecording(false);
+        setRecordedSeconds(0);
+    }, []);
+
+    // Never leave the microphone open because the admin navigated away mid-recording.
+    useEffect(() => teardownRecorder, [teardownRecorder]);
+
+    const handleRecordingStopped = useCallback(
+        async (format: { mime: string; ext: string }) => {
+            const chunks = chunksRef.current;
+            chunksRef.current = [];
+            const discarded = discardRef.current;
+            teardownRecorder();
+            if (discarded || chunks.length === 0) return;
+
+            const blob = new Blob(chunks, { type: format.mime });
+            const file = new File([blob], `voice-note-${Date.now()}.${format.ext}`, {
+                // The bare mime without codec parameters — classifyAttachment matches on it.
+                type: format.mime.split(';')[0],
+            });
+            await stageFile(file);
+        },
+        [stageFile, teardownRecorder]
+    );
+
+    const startRecording = useCallback(async () => {
+        if (mediaSupport !== 'yes') {
+            toast.error(unsupportedMessage('Voice notes'));
+            return;
+        }
+        const format = pickRecordingFormat();
+        if (!format) {
+            toast.error(
+                'This browser can only record WebM audio, which WhatsApp rejects. Try Chrome 126+, Safari or Firefox.'
+            );
+            return;
+        }
+
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            const recorder = new MediaRecorder(stream, { mimeType: format.mime });
+            chunksRef.current = [];
+            discardRef.current = false;
+
+            recorder.ondataavailable = (e) => {
+                if (e.data.size > 0) chunksRef.current.push(e.data);
+            };
+            recorder.onstop = () => void handleRecordingStopped(format);
+
+            recorderRef.current = recorder;
+            recorder.start();
+            setRecording(true);
+            setRecordedSeconds(0);
+            tickRef.current = setInterval(() => setRecordedSeconds((n) => n + 1), 1000);
+        } catch (err) {
+            console.error(err);
+            toast.error('Could not access the microphone. Check the browser permission.');
+        }
+    }, [mediaSupport, unsupportedMessage, handleRecordingStopped]);
+
+    const stopRecording = useCallback((discard: boolean) => {
+        discardRef.current = discard;
+        const recorder = recorderRef.current;
+        if (recorder && recorder.state !== 'inactive') {
+            recorder.stop(); // onstop uploads or discards, then tears down
+        }
+    }, []);
+
+    return {
+        attachment,
+        clearAttachment: () => setAttachment(null),
+        uploading,
+        recording,
+        recordedSeconds,
+        fileInputRef,
+        openFilePicker,
+        handleFilePick,
+        startRecording,
+        stopRecording,
+        unsupportedMessage,
+    };
+}

--- a/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/engine/provider/WatiMessageProvider.java
+++ b/notification_service/src/main/java/vacademy/io/notification_service/features/chatbot_flow/engine/provider/WatiMessageProvider.java
@@ -253,30 +253,8 @@ public class WatiMessageProvider implements ChatbotMessageProvider {
 
         String formattedPhone = phone.replaceAll("[^0-9]", "");
 
-        // WATI has no JSON "send media by URL" endpoint for session messages — the old
-        // /api/ext/v3/conversations/messages/fileViaUrl returns 404. The working path is
-        // /api/v1/sendSessionFile/{whatsappNumber} with a multipart file upload. So download
-        // the media bytes first, then upload them.
-        byte[] fileBytes;
-        try {
-            fileBytes = restTemplate.getForObject(mediaUrl, byte[].class);
-        } catch (Exception e) {
-            log.error("Failed to download media for WATI session file: url={}, error={}", mediaUrl, e.getMessage());
-            throw new RuntimeException("Could not download media: " + e.getMessage());
-        }
-        if (fileBytes == null || fileBytes.length == 0) {
-            throw new RuntimeException("Downloaded media is empty: " + mediaUrl);
-        }
-
-        String safeName = (filename != null && !filename.isBlank()) ? filename : "file";
-        ByteArrayResource resource = new ByteArrayResource(fileBytes) {
-            @Override
-            public String getFilename() {
-                return safeName;
-            }
-        };
         MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
-        form.add("file", resource);
+        form.add("file", downloadAsResource(mediaUrl, filename));
 
         String url = config.apiUrl + "/api/v1/sendSessionFile/" + formattedPhone;
         if (caption != null && !caption.isBlank()) {
@@ -294,20 +272,7 @@ public class WatiMessageProvider implements ChatbotMessageProvider {
             if (!response.getStatusCode().is2xxSuccessful()) {
                 throw new RuntimeException("WATI sendSessionFile returned " + response.getStatusCode());
             }
-            // WATI returns HTTP 200 even on failure — check the "result" flag.
-            if (response.getBody() != null) {
-                JsonNode respJson = objectMapper.readTree(response.getBody());
-                if (respJson.has("result") && respJson.path("result").isBoolean()
-                        && !respJson.path("result").booleanValue()) {
-                    throw new RuntimeException("WATI sendSessionFile result=false: "
-                            + failureReason(respJson));
-                }
-                // Session-file sends usually carry no per-message id; return it when they do so
-                // the caller can attribute delivered/read webhooks to this exact message.
-                String messageId = respJson.path("message").path("whatsappMessageId").asText(null);
-                if (messageId != null && !messageId.isBlank()) return messageId;
-            }
-            return null;
+            return readSessionFileResponse(response.getBody());
         } catch (RuntimeException e) {
             log.error("Failed to send document via WATI sendSessionFile: url={}, error={}", url, e.getMessage());
             throw e;
@@ -315,6 +280,53 @@ public class WatiMessageProvider implements ChatbotMessageProvider {
             log.error("Failed to send document via WATI sendSessionFile: url={}, error={}", url, e.getMessage());
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * WATI has no JSON "send media by URL" endpoint for session messages — the old
+     * /api/ext/v3/conversations/messages/fileViaUrl returns 404. The working path is a multipart
+     * upload, so the bytes have to travel through this service.
+     * <p>
+     * The filename matters more than it looks: WATI infers the media type from it, so a name
+     * without an extension is delivered as a document called "file".
+     */
+    private ByteArrayResource downloadAsResource(String mediaUrl, String filename) {
+        byte[] fileBytes;
+        try {
+            fileBytes = restTemplate.getForObject(mediaUrl, byte[].class);
+        } catch (Exception e) {
+            log.error("Failed to download media for WATI session file: url={}, error={}", mediaUrl, e.getMessage());
+            throw new RuntimeException("Could not download media: " + e.getMessage());
+        }
+        if (fileBytes == null || fileBytes.length == 0) {
+            throw new RuntimeException("Downloaded media is empty: " + mediaUrl);
+        }
+
+        String safeName = (filename != null && !filename.isBlank()) ? filename : "file";
+        return new ByteArrayResource(fileBytes) {
+            @Override
+            public String getFilename() {
+                return safeName;
+            }
+        };
+    }
+
+    /**
+     * The provider message id from a sendSessionFile response, or null when it carries none.
+     * WATI answers HTTP 200 even on failure, so the "result" flag is the real verdict.
+     */
+    private String readSessionFileResponse(String body) throws Exception {
+        if (body == null) return null;
+
+        JsonNode respJson = objectMapper.readTree(body);
+        if (respJson.has("result") && respJson.path("result").isBoolean()
+                && !respJson.path("result").booleanValue()) {
+            throw new RuntimeException("WATI sendSessionFile result=false: " + failureReason(respJson));
+        }
+        // Session-file sends usually carry no per-message id; return it when they do so the caller
+        // can attribute delivered/read webhooks to this exact message.
+        String messageId = respJson.path("message").path("whatsappMessageId").asText(null);
+        return (messageId != null && !messageId.isBlank()) ? messageId : null;
     }
 
     /**

--- a/notification_service/src/test/java/vacademy/io/notification_service/features/chatbot_flow/WhatsAppInboxSendContractTest.java
+++ b/notification_service/src/test/java/vacademy/io/notification_service/features/chatbot_flow/WhatsAppInboxSendContractTest.java
@@ -1,0 +1,175 @@
+package vacademy.io.notification_service.features.chatbot_flow;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import vacademy.io.notification_service.features.chatbot_flow.controller.WhatsAppInboxController;
+import vacademy.io.notification_service.features.chatbot_flow.dto.InboxMessageDTO;
+import vacademy.io.notification_service.features.chatbot_flow.dto.InboxSendRequest;
+import vacademy.io.notification_service.features.chatbot_flow.service.ChatbotEscalationService;
+import vacademy.io.notification_service.features.chatbot_flow.service.WhatsAppInboxService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * The wire contract of {@code POST /inbox/send}, exercised with the exact JSON the admin Inbox
+ * sends.
+ *
+ * This is the seam the service-level tests cannot see. The endpoint used to take a
+ * {@code Map<String,String>} and now binds a DTO, so two things have to stay true at once: an
+ * older client that posts only phone/text/instituteId must keep working untouched, and a body
+ * carrying mediaType + mediaUrl must reach the media path rather than being quietly dropped and
+ * delivered as text — which is exactly what an un-updated backend does with these fields.
+ */
+class WhatsAppInboxSendContractTest {
+
+    private static final String INSTITUTE = "54d0a67f-8a13-4137-872d-f62d68ef7971";
+    private static final String PHONE = "919682419977";
+
+    private WhatsAppInboxService inboxService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        inboxService = mock(WhatsAppInboxService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new WhatsAppInboxController(inboxService, mock(ChatbotEscalationService.class)))
+                .build();
+    }
+
+    private InboxMessageDTO reply() {
+        return InboxMessageDTO.builder().id("log-1").direction("OUTGOING").source("INBOX").build();
+    }
+
+    @Test
+    @DisplayName("the pre-media client's body still routes to the plain text send")
+    void textOnlyBodyIsUnchanged() throws Exception {
+        when(inboxService.sendReply(anyString(), anyString(), anyString(), any()))
+                .thenReturn(reply());
+
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","text":"hello","instituteId":"%s"}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isOk());
+
+        verify(inboxService).sendReply(PHONE, "hello", INSTITUTE, null);
+        verify(inboxService, never()).sendMediaReply(any());
+    }
+
+    @Test
+    @DisplayName("mediaType + mediaUrl reach the media path, with the text as the caption")
+    void mediaBodyRoutesToMediaSend() throws Exception {
+        when(inboxService.sendMediaReply(any())).thenReturn(reply());
+
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","text":"Here is your brochure","instituteId":"%s",
+                                 "mediaType":"image","mediaUrl":"https://cdn.example.com/b.png",
+                                 "filename":"b.png"}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<InboxSendRequest> sent = ArgumentCaptor.forClass(InboxSendRequest.class);
+        verify(inboxService).sendMediaReply(sent.capture());
+        assertThat(sent.getValue().getMediaType()).isEqualTo("image");
+        assertThat(sent.getValue().getMediaUrl()).isEqualTo("https://cdn.example.com/b.png");
+        assertThat(sent.getValue().getFilename()).isEqualTo("b.png");
+        assertThat(sent.getValue().getText()).isEqualTo("Here is your brochure");
+        verify(inboxService, never()).sendReply(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("an attachment with no caption is still a media send, not a rejected empty message")
+    void captionlessMediaIsAccepted() throws Exception {
+        when(inboxService.sendMediaReply(any())).thenReturn(reply());
+
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","instituteId":"%s","mediaType":"audio",
+                                 "mediaUrl":"https://cdn.example.com/voice-note.m4a"}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isOk());
+
+        verify(inboxService).sendMediaReply(any());
+    }
+
+    @Test
+    @DisplayName("force rides through to the service for a 72h or webhook-gap conversation")
+    void forceIsCarried() throws Exception {
+        when(inboxService.sendMediaReply(any())).thenReturn(reply());
+
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","instituteId":"%s","mediaType":"image",
+                                 "mediaUrl":"https://cdn.example.com/a.png","force":true}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<InboxSendRequest> sent = ArgumentCaptor.forClass(InboxSendRequest.class);
+        verify(inboxService).sendMediaReply(sent.capture());
+        assertThat(sent.getValue().isForce()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a field this backend does not know is ignored, not a 400")
+    void unknownFieldsDoNotBreakBinding() throws Exception {
+        when(inboxService.sendReply(anyString(), anyString(), anyString(), any()))
+                .thenReturn(reply());
+
+        // A newer client may send fields this build predates. Binding must not reject the whole
+        // request over one of them.
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","text":"hi","instituteId":"%s","somethingNew":"x"}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("neither text nor media is a bad request, not an empty WhatsApp message")
+    void emptyMessageIsRejected() throws Exception {
+        mockMvc.perform(post("/notification-service/v1/inbox/send")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"phone":"%s","instituteId":"%s"}
+                                """.formatted(PHONE, INSTITUTE)))
+                .andExpect(status().isBadRequest());
+
+        verify(inboxService, never()).sendMediaReply(any());
+        verify(inboxService, never()).sendReply(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("the session window is reported for the composer to gate on")
+    void sessionWindowIsExposed() throws Exception {
+        when(inboxService.sessionWindow(PHONE, INSTITUTE)).thenReturn(
+                vacademy.io.notification_service.features.chatbot_flow.dto.SessionWindowDTO.builder()
+                        .open(true).minutesRemaining(120L).unknown(false).build());
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .get("/notification-service/v1/inbox/conversations/{phone}/session-window", PHONE)
+                        .param("instituteId", INSTITUTE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.open").value(true))
+                .andExpect(jsonPath("$.minutesRemaining").value(120));
+    }
+}


### PR DESCRIPTION
Follow-up to #2805. Those commits were pushed just after it merged, so they did not ride along.

## The bug worth merging

The composer's capability gate only refused when the backend probe answered `'no'`. A probe that was slow, or that failed with a **network** error rather than a 403, left it `'unknown'` — and an attachment sent in that state would have been delivered as **caption-only text with the file silently dropped**. Only `'yes'` is permission now, and it is checked at send time, not just when picking a file.

## CodeFactor (#2805 went in red — all five findings fixed)

- `unicorn/no-useless-spread` — the send-options object held nothing but a spread.
- Complex Method ×3 — the attachment/upload/MediaRecorder concerns are now a `useAttachment` hook instead of living inside `ReplyBox` alongside the text and template flows.
- Complex Method — `WatiMessageProvider.sendMedia` split: the media download and the response reading are their own methods.

## Contract tests

`/inbox/send` used to take a `Map<String,String>` and now binds a DTO. That seam is invisible to the service-level tests and is exactly where a mismatch looks like "the attachment didn't send", with no error anywhere. Pinned with the literal JSON the composer posts: text-only still routes to the text send; `mediaType` + `mediaUrl` reach the media send; a caption-less attachment is accepted; `force` is carried; an unknown field is ignored rather than failing the request; neither text nor media is a 400.

## Verification

105 backend tests pass, `tsc` clean, the new hook lints clean, and the touched files sit below their pre-existing lint counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)